### PR TITLE
memory scale up to 16Gi

### DIFF
--- a/charts/lock-unlock-rewrite/Chart.yaml
+++ b/charts/lock-unlock-rewrite/Chart.yaml
@@ -10,4 +10,4 @@ name: lock-unlock-rewrite
 sources:
   - https://github.com/kadaster-labs/secured-sparql-endpoint-rewrite
 type: application
-version: 0.1.3
+version: 0.1.4

--- a/charts/lock-unlock-rewrite/templates/deployment.yaml
+++ b/charts/lock-unlock-rewrite/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
             - name: FUSEKI_BASE
               value: /run
             - name: JAVA_OPTIONS
-              value: "{{ .Values.javaOptions }}"
+              value: "{{ .Values.image.javaOptions }}"
           ports:
             - name: http
               containerPort: 3030
@@ -70,7 +70,7 @@ spec:
             - name: fuseki-base
               mountPath: /run
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.image.resources | nindent 12 }}
           {{- with .Values.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}

--- a/charts/lock-unlock-rewrite/templates/deployment.yaml
+++ b/charts/lock-unlock-rewrite/templates/deployment.yaml
@@ -56,6 +56,8 @@ spec:
           env:
             - name: FUSEKI_BASE
               value: /run
+            - name: JAVA_OPTIONS
+              value: "{{ .Values.javaOptions }}"
           ports:
             - name: http
               containerPort: 3030

--- a/charts/lock-unlock-rewrite/values.yaml
+++ b/charts/lock-unlock-rewrite/values.yaml
@@ -74,10 +74,12 @@ ingress:
 
 resources:
   limits:
-    memory: 2Gi
+    memory: 16Gi
   requests:
     cpu: 50m
     memory: 2Gi
+
+javaOptions: "-Xmx16g -Xms4g"
 
 autoscaling:
   enabled: false

--- a/charts/lock-unlock-rewrite/values.yaml
+++ b/charts/lock-unlock-rewrite/values.yaml
@@ -9,6 +9,15 @@ image:
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: "0.1.0"
+  
+  resources:
+    limits:
+      memory: 16Gi
+    requests:
+      cpu: 50m
+      memory: 2Gi
+  
+  javaOptions: "-Xmx16g -Xms4g"
 
 dataloader:
   enabled: true
@@ -71,15 +80,6 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
-
-resources:
-  limits:
-    memory: 16Gi
-  requests:
-    cpu: 50m
-    memory: 2Gi
-
-javaOptions: "-Xmx16g -Xms4g"
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
De pods crashen zodra enige load (al bij klein load) wordt gevraagd. Daarom performance tuning van de JVM in de Fuseki (rewrite) container / pod.

- `JAVA_OPTIONS` tuning maakt gebruik van `Xmx` en `Xms` volgens de '[documentatie](https://stackoverflow.com/questions/14763079/what-are-the-xms-and-xmx-parameters-when-starting-jvm)' (😇)
- nu eerst opgeschaald naar **16Gi**; hopelijk beschikbaar in het platform en later terug te schalen obv monitoring en ervaring