### PR TITLE
data.zip with multiple files

### DIFF
--- a/charts/lock-unlock-rewrite/Chart.yaml
+++ b/charts/lock-unlock-rewrite/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.1.0"
+appVersion: "0.1.1"
 description: Helm charts for the Fuseki deployment of Lock-Unlock with Rewrite strategy
 home: https://labs.kadaster.nl/cases/lockunlock
 keywords:
@@ -10,4 +10,4 @@ name: lock-unlock-rewrite
 sources:
   - https://github.com/kadaster-labs/secured-sparql-endpoint-rewrite
 type: application
-version: 0.1.4
+version: 0.1.5

--- a/charts/lock-unlock-rewrite/README.md
+++ b/charts/lock-unlock-rewrite/README.md
@@ -1,6 +1,6 @@
 # lock-unlock-rewrite
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.1](https://img.shields.io/badge/AppVersion-0.1.1-informational?style=flat-square)
 
 Helm charts for the Fuseki deployment of Lock-Unlock with Rewrite strategy
 
@@ -68,13 +68,13 @@ The Java VM requires at least 2Gi of memory to function properly, so the Helm de
 | dataloader.enabled | bool | `true` |  |
 | dataloader.image.pullPolicy | string | `"IfNotPresent"` |  |
 | dataloader.image.repository | string | `"lockunlock.azurecr.io/dataloader"` |  |
-| dataloader.image.tag | string | `"0.1.0"` |  |
+| dataloader.image.tag | string | `"0.1.1"` |  |
 | dataloader.resources.limits.memory | string | `"2Gi"` |  |
 | dataloader.resources.requests.cpu | int | `1` |  |
 | dataloader.resources.requests.memory | string | `"2Gi"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"lockunlock.azurecr.io/rewrite"` |  |
-| image.tag | string | `"0.1.0"` |  |
+| image.tag | string | `"0.1.1"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |

--- a/charts/lock-unlock-rewrite/values.yaml
+++ b/charts/lock-unlock-rewrite/values.yaml
@@ -8,23 +8,23 @@ image:
   repository: lockunlock.azurecr.io/rewrite
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.1.0"
+  tag: "0.1.1"
   
   resources:
     limits:
-      memory: 16Gi
+      memory: 8Gi
     requests:
       cpu: 50m
       memory: 2Gi
   
-  javaOptions: "-Xmx16g -Xms4g"
+  javaOptions: "-Xmx8g -Xms4g"
 
 dataloader:
   enabled: true
 
   image:
     repository: lockunlock.azurecr.io/dataloader
-    tag: "0.1.0"
+    tag: "0.1.1"
     pullPolicy: IfNotPresent
 
   dataset:

--- a/charts/lock-unlock-rewrite/values.yaml
+++ b/charts/lock-unlock-rewrite/values.yaml
@@ -33,7 +33,7 @@ dataloader:
 
   resources:
     limits:
-      memory: 2Gi
+      memory: 4Gi
     requests:
       cpu: 1
       memory: 2Gi

--- a/examples/lock-unlock-rewrite/README.md
+++ b/examples/lock-unlock-rewrite/README.md
@@ -34,7 +34,7 @@ helm upgrade --install fuseki-$DATASET charts/lock-unlock-rewrite \
   --namespace lock-unlock-$DATASET --create-namespace \
   --values examples/lock-unlock-rewrite/values.localhost.yaml \
   --set ingress.hosts\[0\].host=$DATASET.127.0.0.1.nip.io \
-  --set dataloader.dataset.file_url="https://raw.githubusercontent.com/kadaster-labs/lock-unlock-testdata/main/testdata-$DATASET/lock-unlock-$DATASET.ttl.gz" \
+  --set dataloader.dataset.file_url="https://raw.githubusercontent.com/kadaster-labs/lock-unlock-testdata/main/testdata-$DATASET/data.zip" \
   --set dataloader.dataset.endpoint="/$DATASET"
 ```
 

--- a/examples/lock-unlock-rewrite/README.md
+++ b/examples/lock-unlock-rewrite/README.md
@@ -10,10 +10,10 @@ helm upgrade --install ingress-nginx ingress-nginx  \
 The next step assumes you've built the [lock-unlock-rewrite](https://github.com/kadaster-labs/secured-sparql-endpoint-rewrite) and [lock-unlock-dataloader](https://github.com/kadaster-labs/lock-unlock-testdata/tree/main/lock-unlock-dataloader) images in their corresponding repos, as a reminder:
 ```console
 # cd secured-sparql-endpoint-rewrite
-docker build --build-arg JENA_VERSION=4.10.0 --build-arg LOCK_UNLOCK_VERSION=0.1.0 -t lock-unlock/rewrite:0.1.0 -f docker/Dockerfile .
+docker build --build-arg JENA_VERSION=4.10.0 --build-arg LOCK_UNLOCK_VERSION=0.1.1 -t lock-unlock/rewrite:0.1.1 -f docker/Dockerfile .
 
 # cd lock-unlock-testdata
-docker build -t lock-unlock/dataloader:0.1.0 ./lock-unlock-dataloader
+docker build -t lock-unlock/dataloader:0.1.1 ./lock-unlock-dataloader
 ```
 
 Then, the example deployment for a BRK deployment can be done using the following command:

--- a/examples/lock-unlock-rewrite/values.localhost.yaml
+++ b/examples/lock-unlock-rewrite/values.localhost.yaml
@@ -1,13 +1,13 @@
 image:
   repository: lock-unlock/rewrite
   pullPolicy: Never
-  tag: "0.1.0"
+  # tag: "0.1.1"
 
 dataloader:
   image:
     repository: lock-unlock/dataloader
     pullPolicy: Never
-    tag: "0.1.0"
+    # tag: "0.1.1"
 
   dataset:
     file_url: "https://raw.githubusercontent.com/kadaster-labs/lock-unlock-testdata/main/testdata-brk/data.zip"

--- a/examples/lock-unlock-rewrite/values.localhost.yaml
+++ b/examples/lock-unlock-rewrite/values.localhost.yaml
@@ -10,7 +10,7 @@ dataloader:
     tag: "0.1.0"
 
   dataset:
-    file_url: "https://raw.githubusercontent.com/kadaster-labs/lock-unlock-testdata/main/testdata-brk/lock-unlock-brk.ttl.gz"
+    file_url: "https://raw.githubusercontent.com/kadaster-labs/lock-unlock-testdata/main/testdata-brk/data.zip"
     endpoint: "/brk"
 
 ingress:

--- a/examples/lock-unlock-rewrite/values.localhost.yaml
+++ b/examples/lock-unlock-rewrite/values.localhost.yaml
@@ -1,13 +1,13 @@
 image:
   repository: lock-unlock/rewrite
   pullPolicy: Never
-  # tag: "0.1.1"
+  tag: "0.1.1"
 
 dataloader:
   image:
     repository: lock-unlock/dataloader
     pullPolicy: Never
-    # tag: "0.1.1"
+    tag: "0.1.1"
 
   dataset:
     file_url: "https://raw.githubusercontent.com/kadaster-labs/lock-unlock-testdata/main/testdata-brk/data.zip"


### PR DESCRIPTION
De testdata is van een enkele `.ttl` file naar multiple `.trig` files aan het veranderen ... en daarvoor dient de dataloader aangepast te worden én dan ook de deployment charts. Tijdens het testen kwam al aan het licht dat de resources voor de dataloader ook te klein zijn en dus moeten worden verhoogd.

Wijzigingen:

- [x] `$DATASET.ttl.gz` -> `data.zip`
- [x] resources verhoogd van `dataloader` image (met ondersteuning voor `.zip` met multiple files; zie [prep_tbd2 script](https://github.com/kadaster-labs/lock-unlock-testdata/blob/main/lock-unlock-dataloader/prep_tdb2.sh))
- [x] nieuwe versie van `dataloader` image
- [x] nieuwe versie van `rewrite` image